### PR TITLE
Temporarily removed dpi scaling

### DIFF
--- a/source/Settings.au3
+++ b/source/Settings.au3
@@ -22,7 +22,6 @@
 #Region MetroGUI settings
 
 #Au3Stripper_Ignore_Funcs=_iHoverOn,_iHoverOff,_iFullscreenToggleBtn,_cHvr_CSCP_X64,_cHvr_CSCP_X86,_iControlDelete
-_Metro_EnableHighDPIScaling() ; Note: Requries "#AutoIt3Wrapper_Res_HiDpi=y" for compiling.
 _SetTheme("DarkBlue")
 
 #EndRegion MetroGUI settings
@@ -32,6 +31,7 @@ AutoItSetOption("GUICloseOnESC", 0)
 
 ;Create resizable Metro GUI
 $Form1 = _Metro_CreateGUI("SimpleR Settings", 800, 700, -1, -1, True)
+_Metro_EnableHighDPIScaling() ; Note: Requries "#AutoIt3Wrapper_Res_HiDpi=y" for compiling.
 
 ;Add/create control buttons to the GUI
 $Control_Buttons = _Metro_AddControlButtons(True, True, True, True, True) ;CloseBtn = True, MaximizeBtn = True, MinimizeBtn = True, FullscreenBtn = True, MenuBtn = True

--- a/source/Settings.au3
+++ b/source/Settings.au3
@@ -22,7 +22,6 @@
 #Region MetroGUI settings
 
 #Au3Stripper_Ignore_Funcs=_iHoverOn,_iHoverOff,_iFullscreenToggleBtn,_cHvr_CSCP_X64,_cHvr_CSCP_X86,_iControlDelete
-_Metro_EnableHighDPIScaling() ; Note: Requries "#AutoIt3Wrapper_Res_HiDpi=y" for compiling.
 _SetTheme("DarkBlue")
 
 #EndRegion MetroGUI settings

--- a/source/Settings.au3
+++ b/source/Settings.au3
@@ -4,7 +4,7 @@
 #AutoIt3Wrapper_Res_Description=Settings GUI for SimpleR
 #AutoIt3Wrapper_Res_Fileversion=1.0.0.0
 #AutoIt3Wrapper_Res_Fileversion_AutoIncrement=p
-#AutoIt3Wrapper_Res_HiDpi=y
+#AutoIt3Wrapper_Res_HiDpi=n
 #AutoIt3Wrapper_Run_Au3Stripper=y
 #Au3Stripper_Parameters=/so /rm /pe
 #EndRegion ;**** Directives created by AutoIt3Wrapper_GUI ****

--- a/source/Settings.au3
+++ b/source/Settings.au3
@@ -22,6 +22,7 @@
 #Region MetroGUI settings
 
 #Au3Stripper_Ignore_Funcs=_iHoverOn,_iHoverOff,_iFullscreenToggleBtn,_cHvr_CSCP_X64,_cHvr_CSCP_X86,_iControlDelete
+_Metro_EnableHighDPIScaling() ; Note: Requries "#AutoIt3Wrapper_Res_HiDpi=y" for compiling.
 _SetTheme("DarkBlue")
 
 #EndRegion MetroGUI settings
@@ -31,7 +32,6 @@ AutoItSetOption("GUICloseOnESC", 0)
 
 ;Create resizable Metro GUI
 $Form1 = _Metro_CreateGUI("SimpleR Settings", 800, 700, -1, -1, True)
-_Metro_EnableHighDPIScaling() ; Note: Requries "#AutoIt3Wrapper_Res_HiDpi=y" for compiling.
 
 ;Add/create control buttons to the GUI
 $Control_Buttons = _Metro_AddControlButtons(True, True, True, True, True) ;CloseBtn = True, MaximizeBtn = True, MinimizeBtn = True, FullscreenBtn = True, MenuBtn = True

--- a/source/SimpleR.au3
+++ b/source/SimpleR.au3
@@ -6,7 +6,7 @@
 #AutoIt3Wrapper_Res_Fileversion_AutoIncrement=p
 #AutoIt3Wrapper_Res_LegalCopyright=GerRudi
 #AutoIt3Wrapper_Res_Language=1033
-#AutoIt3Wrapper_Res_HiDpi=y
+#AutoIt3Wrapper_Res_HiDpi=n
 #AutoIt3Wrapper_Run_Au3Stripper=y
 #Au3Stripper_Parameters=/so /rm /pe
 #EndRegion ;**** Directives created by AutoIt3Wrapper_GUI ****

--- a/source/SimpleR.au3
+++ b/source/SimpleR.au3
@@ -63,7 +63,6 @@ AutoItSetOption("SendKeyDelay", 1)
 AutoItSetOption("SendKeyDownDelay", 1)
 
 Func main()
-    _Metro_EnableHighDPIScaling()
 	$savedGeneral = GetGeneral()
 	$savedPaths = GetPaths()
 

--- a/source/SimpleR.au3
+++ b/source/SimpleR.au3
@@ -63,7 +63,7 @@ AutoItSetOption("SendKeyDelay", 1)
 AutoItSetOption("SendKeyDownDelay", 1)
 
 Func main()
-
+    _Metro_EnableHighDPIScaling()
 	$savedGeneral = GetGeneral()
 	$savedPaths = GetPaths()
 


### PR DESCRIPTION
For the settings the setting was moved after the init.
In the SimpleR DPI scaling needed to be activated.

Fixes #3 